### PR TITLE
Added a new events endpoint

### DIFF
--- a/src/controllers/events/event.ts
+++ b/src/controllers/events/event.ts
@@ -11,8 +11,8 @@ const getEvents = async (): Promise<Event[]> => {
     }
 
     const events: Event[] = snapshot.docs.map(doc => ({
-        id: doc.id,
-        ...doc.data() as Omit<Event, 'id'>
+        event_Id: doc.id,
+        ...doc.data() as Omit<Event, 'event_Id'>
     }));
 
     return events;
@@ -28,13 +28,11 @@ const getEventById = async (id: string): Promise<Event | null> => {
     }
 
     const event: Event = {
-        ...doc.data() as Omit<Event, 'id'>
+        event_Id: id,
+        ...doc.data() as Omit<Event, 'event_Id'>
     };
 
     return event;
 };
-
-getEvents().then(events => console.log(events)).catch(console.error);
-getEventById('SodBmUY6as6qgI55L0bh').then(event => console.log(event)).catch(console.error);
 
 export { getEvents, getEventById };

--- a/src/controllers/events/event.ts
+++ b/src/controllers/events/event.ts
@@ -1,0 +1,40 @@
+import { db } from "../../config/firebase";
+import { Event } from "./types";
+
+const getEvents = async (): Promise<Event[]> => {
+    const eventsCollection = db.collection('events');
+    const snapshot = await eventsCollection.get();
+
+    if (snapshot.empty) {
+        console.log('No matching documents.');
+        return [];
+    }
+
+    const events: Event[] = snapshot.docs.map(doc => ({
+        id: doc.id,
+        ...doc.data() as Omit<Event, 'id'>
+    }));
+
+    return events;
+};
+
+const getEventById = async (id: string): Promise<Event | null> => {
+    const eventDoc = db.collection('events').doc(id);
+    const doc = await eventDoc.get();
+
+    if (!doc.exists) {
+        console.log('No such document!');
+        return null;
+    }
+
+    const event: Event = {
+        ...doc.data() as Omit<Event, 'id'>
+    };
+
+    return event;
+};
+
+getEvents().then(events => console.log(events)).catch(console.error);
+getEventById('SodBmUY6as6qgI55L0bh').then(event => console.log(event)).catch(console.error);
+
+export { getEvents, getEventById };

--- a/src/controllers/events/types.ts
+++ b/src/controllers/events/types.ts
@@ -1,0 +1,14 @@
+
+type Event = {
+    event_Id: string
+    name: string
+    date: Date
+    location: string
+    description: string
+    media: string[]
+    price: number
+    attendees: string[]
+    member_only: boolean
+}
+
+export { Event }

--- a/src/routes/event.ts
+++ b/src/routes/event.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { getEvents, getEventById } from "../controllers/events/event";
+
+export const eventRouter = Router()
+
+eventRouter.get('/', async (req, res) => {
+    try {
+        const events = await getEvents();
+        res.status(200).json(events);
+    } catch (error: any) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+eventRouter.get('/:id', async (req, res) => {
+    try {
+        const eventByID = await getEventById(req.params.id);
+        res.status(200).json(eventByID);
+    } catch (error: any) {
+        res.status(500).json({ error: error.message });
+    }
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,12 @@
 import { Router } from "express";
 import { authRouter } from "./auth";
+import { eventRouter } from "./event";
 
 export const apiRouter = Router()
 
 apiRouter.use("/auth", authRouter)
+apiRouter.use("/events", eventRouter)
+
+
 
 // other routes go here


### PR DESCRIPTION
I created a new collection in the firestore database called 'Events'. In the collection, I created a sample event with the ID: SodBmUY6as6qgI55L0bh (you can check it, it's called Product Sprint hehe)

How to test:
Visit http://localhost:8000/api/v1/events/ to see the list of all events. OR visit http://localhost:8000/api/v1/events/SodBmUY6as6qgI55L0bh to see the properties of the event. 

It should look smtg like {
  "date": {
    "_seconds": 1720715512,
    "_nanoseconds": 154000000
  },
  "thumbnail": "http://drive.google.com",
  "attendees": [],
  "price": 0,
  "name": "product sprint",
  "description": "good event. u should come",
  "location": "UBC",
  "media": [
    "http://drive.google.com"
  ],
  "member_only": true
}.