### PR TITLE
add stripe payment verification

### DIFF
--- a/src/routes/v2/stripe.ts
+++ b/src/routes/v2/stripe.ts
@@ -1,31 +1,73 @@
 import { Router } from "express";
 import { stripe } from "../../config/stripe";
+import { supabase } from "../../config/supabase";
 import { Stripe } from "stripe";
 import express from "express";
+import { Status } from "../../services/payments/PaymentService";
 
 export const webhookRouter = Router();
 
-webhookRouter.post("/", express.raw({ type: "application/json" }), (req, res) => {
+webhookRouter.post("/", express.raw({ type: "application/json" }), async (req, res) => {
     try {
         const sig = req.headers["stripe-signature"] as string;
         const event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET!);
 
-        if (event.type === "payment_intent.succeeded") {
-            const paymentIntent = event.data.object as Stripe.PaymentIntent;
-            console.log("Payment intent succeeded:", paymentIntent.id, paymentIntent.amount, paymentIntent.currency, paymentIntent.status, paymentIntent.payment_method);
-        }
-
-        if (event.type === "payment_intent.processing") {
-            const paymentIntent = event.data.object as Stripe.PaymentIntent;
-            console.log("Payment intent processing:", paymentIntent.id, paymentIntent.amount, paymentIntent.currency, paymentIntent.status, paymentIntent.payment_method);
-        }
-
-        if (event.type === "payment_intent.canceled") {
-            const paymentIntent = event.data.object as Stripe.PaymentIntent;
-            console.log("Payment intent canceled:", paymentIntent.id, paymentIntent.amount, paymentIntent.currency, paymentIntent.status, paymentIntent.payment_method);
-        }
-
+        // responds 200 to stripe immediately
         res.status(200).send();
+
+        // this allows the db to be handled in the background without delaying response to stripe (avoids retry from stripe)
+        setImmediate(async () => {
+            switch (event.type) {
+                case "payment_intent.succeeded": {
+                    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+                    const userId = paymentIntent.metadata?.user_id;
+                    const paymentType = paymentIntent.metadata?.payment_type;
+
+                    const { error } = await supabase.from("Payment").update({ status: Status.PAYMENT_SUCCESS }).eq("payment_id", paymentIntent.id);
+                    if (error) {
+                        console.error("Payment success update err:", error);
+                    }
+
+                    if (paymentType === "membership") {
+                        const { error } = await supabase.from("User").update({ is_payment_verified: true }).eq("user_id", userId);
+                        if (error) {
+                            console.error("User verify update err:", error);
+                        }
+
+                        console.log(`Membership PaymentIntent for ${userId} succeeded: ${paymentIntent.id}`);
+                    }
+
+                    break;
+                }
+
+                case "payment_intent.canceled": {
+                    break;
+                }
+
+                case "payment_intent.processing": {
+                    break;
+                }
+
+                case "payment_intent.payment_failed": {
+                    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+                    const userId = paymentIntent.metadata?.user_id;
+                    const paymentType = paymentIntent.metadata?.payment_type;
+
+                    if (paymentType === "membership") {
+                        const { error } = await supabase.from("Payment").update({ status: Status.PAYMENT_FAILED }).eq("payment_id", paymentIntent.id);
+                        if (error) {
+                            console.error("Payment fail update err:", error);
+                        }
+
+                        console.log(`Membership PaymentIntent for ${userId} failed: ${paymentIntent.id}`);
+                    }
+
+                    break;
+                }
+                default:
+                // console.log(`Unhandled event type ${event.type}`);
+            }
+        });
     } catch (error) {
         console.error("Webhook Error:", error);
         return res.status(400).send(`Webhook Error: ${error}`);

--- a/src/routes/v2/stripe.ts
+++ b/src/routes/v2/stripe.ts
@@ -3,7 +3,7 @@ import { stripe } from "../../config/stripe";
 import { supabase } from "../../config/supabase";
 import { Stripe } from "stripe";
 import express from "express";
-import { Status } from "../../services/payments/PaymentService";
+import { handleStripeEvent } from "../../services/payments/PaymentService";
 
 export const webhookRouter = Router();
 
@@ -15,58 +15,8 @@ webhookRouter.post("/", express.raw({ type: "application/json" }), async (req, r
         // responds 200 to stripe immediately
         res.status(200).send();
 
-        // this allows the db to be handled in the background without delaying response to stripe (avoids retry from stripe)
-        setImmediate(async () => {
-            switch (event.type) {
-                case "payment_intent.succeeded": {
-                    const paymentIntent = event.data.object as Stripe.PaymentIntent;
-                    const userId = paymentIntent.metadata?.user_id;
-                    const paymentType = paymentIntent.metadata?.payment_type;
-
-                    const { error } = await supabase.from("Payment").update({ status: Status.PAYMENT_SUCCESS }).eq("payment_id", paymentIntent.id);
-                    if (error) {
-                        console.error("Payment success update err:", error);
-                    }
-
-                    if (paymentType === "membership") {
-                        const { error } = await supabase.from("User").update({ is_payment_verified: true }).eq("user_id", userId);
-                        if (error) {
-                            console.error("User verify update err:", error);
-                        }
-
-                        console.log(`Membership PaymentIntent for ${userId} succeeded: ${paymentIntent.id}`);
-                    }
-
-                    break;
-                }
-
-                case "payment_intent.canceled": {
-                    break;
-                }
-
-                case "payment_intent.processing": {
-                    break;
-                }
-
-                case "payment_intent.payment_failed": {
-                    const paymentIntent = event.data.object as Stripe.PaymentIntent;
-                    const userId = paymentIntent.metadata?.user_id;
-                    const paymentType = paymentIntent.metadata?.payment_type;
-
-                    if (paymentType === "membership") {
-                        const { error } = await supabase.from("Payment").update({ status: Status.PAYMENT_FAILED }).eq("payment_id", paymentIntent.id);
-                        if (error) {
-                            console.error("Payment fail update err:", error);
-                        }
-
-                        console.log(`Membership PaymentIntent for ${userId} failed: ${paymentIntent.id}`);
-                    }
-
-                    break;
-                }
-                default:
-                // console.log(`Unhandled event type ${event.type}`);
-            }
+        handleStripeEvent(event).catch((error) => {
+            console.error("Error handling Stripe event:", error);
         });
     } catch (error) {
         console.error("Webhook Error:", error);

--- a/src/services/payments/PaymentService.ts
+++ b/src/services/payments/PaymentService.ts
@@ -1,44 +1,41 @@
 import { date } from "zod";
-import { stripe } from "../../config/firebase"
-import { supabase } from "../../config/supabase"
+import { stripe } from "../../config/firebase";
+import { supabase } from "../../config/supabase";
 import { Database } from "../../schema/v2/database.types";
 
-type PaymentInsert = Database['public']['Tables']['Payment']['Insert'];
-enum Status {
-  PAYMENT_SUCCESS = "PAYMENT_SUCCESS",
-  PAYMENT_FAILED = "PAYMENT_FAILED",
-  PAYMENT_PENDING = "PAYMENT_PENDING",
+type PaymentInsert = Database["public"]["Tables"]["Payment"]["Insert"];
+export enum Status {
+    PAYMENT_SUCCESS = "PAYMENT_SUCCESS",
+    PAYMENT_FAILED = "PAYMENT_FAILED",
+    PAYMENT_PENDING = "PAYMENT_PENDING",
 }
 
 // in cents
-const MEMBERSHIP_FEE_UBC = 1067
-const MEMBERSHIP_FEE_NONUBC = 1567
+const MEMBERSHIP_FEE_UBC = 1067;
+const MEMBERSHIP_FEE_NONUBC = 1567;
 
-async function createEventPaymentIntent(eventId: string) {
-
-}
+async function createEventPaymentIntent(eventId: string) {}
 
 async function createMembershipPaymentIntent(userId: string) {
-
-    const {data, error} = await supabase
-        .from('User')
-        .select('university')
-        .eq('user_id', userId)
-        .single()
+    const { data, error } = await supabase.from("User").select("university").eq("user_id", userId).single();
 
     if (error) {
         throw new Error(error.message);
     }
 
-    const isUBC = data.university === 'University of British Columbia'
+    const isUBC = data.university === "University of British Columbia";
     const amount = isUBC ? MEMBERSHIP_FEE_UBC : MEMBERSHIP_FEE_NONUBC;
 
     const paymentIntent = await stripe.paymentIntents.create({
         amount: amount,
         currency: "cad",
+        metadata: {
+            user_id: userId,
+            payment_type: "membership",
+        },
     });
 
-    const paymentInsertion : PaymentInsert = {
+    const paymentInsertion: PaymentInsert = {
         amount,
         payment_date: new Date().toISOString(),
         payment_id: paymentIntent.id,
@@ -47,17 +44,13 @@ async function createMembershipPaymentIntent(userId: string) {
         status: Status.PAYMENT_PENDING,
     };
 
-    const {data: payment, error:paymentError} = await supabase
-        .from('Payment')
-        .insert(paymentInsertion)
-        .select()
-        .single()
+    const { data: payment, error: paymentError } = await supabase.from("Payment").insert(paymentInsertion).select().single();
 
     if (paymentError) {
-        throw new Error(paymentError.message)
+        throw new Error(paymentError.message);
     }
 
-    return paymentIntent
+    return paymentIntent;
 }
 
-export { MEMBERSHIP_FEE_UBC, MEMBERSHIP_FEE_NONUBC, createMembershipPaymentIntent}
+export { MEMBERSHIP_FEE_UBC, MEMBERSHIP_FEE_NONUBC, createMembershipPaymentIntent };

--- a/src/services/payments/PaymentService.ts
+++ b/src/services/payments/PaymentService.ts
@@ -55,12 +55,12 @@ async function createMembershipPaymentIntent(userId: string) {
 }
 
 async function handleStripeEvent(event: Stripe.Event) {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+    const userId = paymentIntent.metadata?.user_id;
+    const paymentType = paymentIntent.metadata?.payment_type;
+
     switch (event.type) {
         case "payment_intent.succeeded": {
-            const paymentIntent = event.data.object as Stripe.PaymentIntent;
-            const userId = paymentIntent.metadata?.user_id;
-            const paymentType = paymentIntent.metadata?.payment_type;
-
             const { error } = await supabase.from("Payment").update({ status: Status.PAYMENT_SUCCESS }).eq("payment_id", paymentIntent.id);
             if (error) {
                 console.error("Payment success update err:", error);
@@ -87,10 +87,6 @@ async function handleStripeEvent(event: Stripe.Event) {
         }
 
         case "payment_intent.payment_failed": {
-            const paymentIntent = event.data.object as Stripe.PaymentIntent;
-            const userId = paymentIntent.metadata?.user_id;
-            const paymentType = paymentIntent.metadata?.payment_type;
-
             if (paymentType === "membership") {
                 const { error } = await supabase.from("Payment").update({ status: Status.PAYMENT_FAILED }).eq("payment_id", paymentIntent.id);
                 if (error) {


### PR DESCRIPTION
Resolves #91

## Description
What changes does this PR include? Is there anything that affects other features that people should be aware of?
- Webhook is now able to verify users when the payment intent succeeds, and also checks when it fails.
- Sends 200 status right away to avoid Stripe retries and runs DB work in the background
- Use payment intent metadata to update payment and user status in Supabase (should also be used for event payments in the future)

## Checklist
- [X] This code builds and runs
- [X] I've added feature flags where necessary
- [X] All public classes and methods are documented, as well as hard-to-understand areas of the code
- [X] I've added tests where necessary
- [X] Self-review done
