### PR TITLE
Recruiting form endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1764,6 +1765,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -2071,6 +2073,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.24.tgz",
       "integrity": "sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2635,6 +2638,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -7403,6 +7407,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7495,6 +7500,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/routes/v2/admin/index.ts
+++ b/src/routes/v2/admin/index.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { userRouter} from "./users";
 import { eventRouter } from "./event";
+import { recruitingFormRouter } from "./recruitingForm";
 
 export const adminRouter = Router();
 
 adminRouter.use("/users", userRouter)
 adminRouter.use("/events", eventRouter)
+adminRouter.use("/recruiting-forms", recruitingFormRouter)
 

--- a/src/routes/v2/admin/recruitingForm.ts
+++ b/src/routes/v2/admin/recruitingForm.ts
@@ -1,0 +1,45 @@
+import { Request, Response, Router } from "express";
+import { RecruitingFormSchema } from "../../../schema/v2/RecruitingForm";
+import { createForm, getFormById, listForms } from "../../../services/RecruitingForm/RecruitingFormService";
+
+export const recruitingFormRouter = Router();
+
+recruitingFormRouter.post("/", async (req: Request, res: Response) => {
+    const result = RecruitingFormSchema.safeParse(req.body);
+    if (!result.success) {
+        return res.status(400).json({ error: result.error.message });
+    }
+
+    try {
+        const form = await createForm(result.data);
+        res.status(201).json(form);
+    } catch (error: any) {
+        console.error("Failed to create recruiting form:", error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+recruitingFormRouter.get("/", async (req: Request, res: Response) => {
+    try {
+        const forms = await listForms();
+        res.status(200).json(forms);
+    } catch (error: any) {
+        console.error("Failed to list recruiting forms:", error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+recruitingFormRouter.get("/:formId", async (req: Request, res: Response) => {
+    const formId = req.params.formId;
+
+    try {
+        const form = await getFormById(formId);
+        if (!form) {
+            return res.status(404).json({ error: "Recruiting form not found" });
+        }
+        res.status(200).json(form);
+    } catch (error: any) {
+        console.error("Failed to fetch recruiting form:", error);
+        res.status(500).json({ error: error.message });
+    }
+});

--- a/src/schema/v2/RecruitingForm.ts
+++ b/src/schema/v2/RecruitingForm.ts
@@ -1,0 +1,23 @@
+import { z } from "zod/v4";
+import { Constants } from "./database.types";
+
+const QuestionSchema = z.object({
+    label: z.string(),
+    questionType: z.enum(['short-answer', 'long-answer', 'dropdown', 'checkbox', 'radio', 'file']),
+    options: z.array(z.string()).optional(),
+    required: z.boolean().optional()
+});
+
+export const RecruitingFormSchema = z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    role: z.string().optional(),
+    season: z.string().optional(),
+    year: z.number().optional(),
+    questions: z.array(QuestionSchema),
+    status: z.enum(Constants.public.Enums.RECRUITING_FORM_STATUS).default("DRAFT"),
+    opens_at: z.string().optional(),
+    closes_at: z.string().optional(),
+});
+
+export type RecruitingFormInsert = z.infer<typeof RecruitingFormSchema>;

--- a/src/schema/v2/database.types.ts
+++ b/src/schema/v2/database.types.ts
@@ -124,6 +124,7 @@ export type Database = {
           created_at: string | null
           deliverable_id: string
           event_id: string
+          phase_id: string
           submission: Json | null
           submitted_at: string | null
           submitted_by: string | null
@@ -134,6 +135,7 @@ export type Database = {
           created_at?: string | null
           deliverable_id?: string
           event_id: string
+          phase_id?: string
           submission?: Json | null
           submitted_at?: string | null
           submitted_by?: string | null
@@ -144,6 +146,7 @@ export type Database = {
           created_at?: string | null
           deliverable_id?: string
           event_id?: string
+          phase_id?: string
           submission?: Json | null
           submitted_at?: string | null
           submitted_by?: string | null
@@ -262,6 +265,7 @@ export type Database = {
           registration_closes: string | null
           registration_opens: string | null
           start_time: string | null
+          thumbnail: string | null
           waitlist_form: string | null
         }
         Insert: {
@@ -286,6 +290,7 @@ export type Database = {
           registration_closes?: string | null
           registration_opens?: string | null
           start_time?: string | null
+          thumbnail?: string | null
           waitlist_form?: string | null
         }
         Update: {
@@ -310,7 +315,32 @@ export type Database = {
           registration_closes?: string | null
           registration_opens?: string | null
           start_time?: string | null
+          thumbnail?: string | null
           waitlist_form?: string | null
+        }
+        Relationships: []
+      }
+      execs: {
+        Row: {
+          birthday: string | null
+          id: number
+          name: string
+          roles: string[] | null
+          slack_user_id: string
+        }
+        Insert: {
+          birthday?: string | null
+          id?: never
+          name: string
+          roles?: string[] | null
+          slack_user_id: string
+        }
+        Update: {
+          birthday?: string | null
+          id?: never
+          name?: string
+          roles?: string[] | null
+          slack_user_id?: string
         }
         Relationships: []
       }
@@ -361,6 +391,48 @@ export type Database = {
         Update: {
           id?: string
           product?: string
+        }
+        Relationships: []
+      }
+      Recruiting: {
+        Row: {
+          closes_at: string | null
+          created_at: string | null
+          description: string | null
+          opens_at: string | null
+          questions: Json | null
+          recruiting_id: string
+          role: string | null
+          season: string | null
+          status: Database["public"]["Enums"]["RECRUITING_FORM_STATUS"] | null
+          title: string
+          year: number | null
+        }
+        Insert: {
+          closes_at?: string | null
+          created_at?: string | null
+          description?: string | null
+          opens_at?: string | null
+          questions?: Json | null
+          recruiting_id?: string
+          role?: string | null
+          season?: string | null
+          status?: Database["public"]["Enums"]["RECRUITING_FORM_STATUS"] | null
+          title: string
+          year?: number | null
+        }
+        Update: {
+          closes_at?: string | null
+          created_at?: string | null
+          description?: string | null
+          opens_at?: string | null
+          questions?: Json | null
+          recruiting_id?: string
+          role?: string | null
+          season?: string | null
+          status?: Database["public"]["Enums"]["RECRUITING_FORM_STATUS"] | null
+          title?: string
+          year?: number | null
         }
         Relationships: []
       }
@@ -533,6 +605,7 @@ export type Database = {
         | "REGISTERED"
         | "ACCEPTED"
       PAYMENT_STATUS: "PROCESSING" | "VERIFIED"
+      RECRUITING_FORM_STATUS: "DRAFT" | "PUBLISHED" | "CLOSED"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -668,6 +741,7 @@ export const Constants = {
         "ACCEPTED",
       ],
       PAYMENT_STATUS: ["PROCESSING", "VERIFIED"],
+      RECRUITING_FORM_STATUS: ["DRAFT", "PUBLISHED", "CLOSED"],
     },
   },
 } as const

--- a/src/services/RecruitingForm/RecruitingFormService.ts
+++ b/src/services/RecruitingForm/RecruitingFormService.ts
@@ -1,0 +1,25 @@
+import { Tables } from "../../schema/v2/database.types";
+import { RecruitingFormInsert } from "../../schema/v2/RecruitingForm";
+import { RecruitingFormRepository } from "../../storage/RecruitingFormRepository";
+
+type RecruitingFormRow = Tables<"Recruiting">;
+
+export const createForm = async (form: RecruitingFormInsert) => {
+  const { data, error } = await RecruitingFormRepository.createForm(form);
+  if (error) throw new Error(error.message);
+  return data;
+};
+
+export const getFormById = async (
+  id: string
+): Promise<RecruitingFormRow | null> => {
+  const { data, error } = await RecruitingFormRepository.getFormById(id);
+  if (error) throw new Error(error.message);
+  return data;
+};
+
+export const listForms = async () => {
+  const { data, error } = await RecruitingFormRepository.listForms();
+  if (error) throw new Error(error.message);
+  return data;
+};

--- a/src/storage/RecruitingFormRepository.ts
+++ b/src/storage/RecruitingFormRepository.ts
@@ -1,2 +1,11 @@
-import {supabase} from "../config/supabase";
-import { Tables } from "../schema/v2/database.types";
+import { supabase } from "../config/supabase";
+import { RecruitingFormInsert } from "../schema/v2/RecruitingForm";
+
+export const RecruitingFormRepository = {
+  createForm: (form: RecruitingFormInsert) =>
+    supabase.from("Recruiting").insert(form).select().single(),
+  getFormById: (id: string) =>
+    supabase.from("Recruiting").select("*").eq("recruiting_id", id).maybeSingle(),
+  listForms: () =>
+    supabase.from("Recruiting").select("*").order("created_at", { ascending: false }),
+};

--- a/src/storage/RecruitingFormRepository.ts
+++ b/src/storage/RecruitingFormRepository.ts
@@ -1,0 +1,2 @@
+import {supabase} from "../config/supabase";
+import { Tables } from "../schema/v2/database.types";

--- a/supabase/.temp/linked-project.json
+++ b/supabase/.temp/linked-project.json
@@ -1,0 +1,1 @@
+{"ref":"dthvbanipvldaiabgvuc","name":"PMC Membership Staging","organization_id":"zselljsnfnybfogvnvze","organization_slug":"zselljsnfnybfogvnvze"}

--- a/tests/services/Attendee/AttendeeService.test.ts
+++ b/tests/services/Attendee/AttendeeService.test.ts
@@ -32,6 +32,7 @@ describe("AttendeeService", () => {
     start_time: "2025-07-24T21:30:00+00:00",
     end_time: "2025-07-24T22:30:00+00:00",
     location: "UBC Sauder Building",
+    thumbnail: null,
     member_price: 1,
     non_member_price: 2,
     member_price_id: "",


### PR DESCRIPTION
## Summary
- Add `Recruiting` table schema: Zod validation (`RecruitingForm.ts`), generated Supabase types, `RECRUITING_FORM_STATUS` enum.
- Add `RecruitingFormRepository`, `RecruitingFormService`, and admin routes for creating, listing, and fetching recruiting forms.
- `POST /v2/admin/recruiting-forms`, `GET /v2/admin/recruiting-forms`, `GET /v2/admin/recruiting-forms/:formId` — admin auth enforced via existing `supabaseJwtCheck`, invalid bodies rejected via Zod.


## Test plan
- Verified locally against the live `Recruiting` table: create → fetch by id → list all returned valid data.
- Confirmed auth gate rejects missing/invalid bearer tokens (401).

## Follow-ups (not in this PR)
- No endpoint yet transitions a form to `PUBLISHED`/`CLOSED`.
- No tracked SQL migration for the `Recruiting` table/enum — schema applied directly in Supabase.