### PR TITLE
Feat/applicant submission endpoints

### DIFF
--- a/src/config/recruitingQuestions.ts
+++ b/src/config/recruitingQuestions.ts
@@ -1,0 +1,156 @@
+// Recruiting application questions, split into a base set (asked of every
+// applicant) and role-specific sets. Seeded from the Spring '26 Exec Hiring form.
+//
+// This is intentionally a config file for now so the frontend can render forms
+// immediately. When #174 (recruiting form schema) lands, these definitions move
+// into the DB so execs can edit them from the admin portal — same shape.
+
+export type QuestionType =
+    | "short_text"
+    | "long_text"
+    | "select"
+    | "multi_select";
+
+export interface Question {
+    key: string;
+    label: string;
+    type: QuestionType;
+    required: boolean;
+    maxWords?: number;
+    options?: string[];
+}
+
+// The exec positions applicants can apply for (one application per position).
+export const POSITIONS = [
+    "VP Events",
+    "Events Director",
+    "VP Community",
+    "Community Director",
+    "Design Director",
+    "Marketing Director",
+    "Media Director",
+    "Finance Director",
+    "Product Designer",
+    "Developer",
+    "Corporate Outreach Director",
+    "Mentor Outreach Director",
+    "Program Director",
+    "Program Outreach Director",
+] as const;
+
+export type Position = (typeof POSITIONS)[number];
+
+// Asked of every applicant regardless of position.
+export const BASE_QUESTIONS: Question[] = [
+    { key: "first_name", label: "First Name", type: "short_text", required: true },
+    { key: "last_name", label: "Last Name", type: "short_text", required: true },
+    { key: "student_number", label: "Student Number", type: "short_text", required: true },
+    { key: "email", label: "Email", type: "short_text", required: true },
+    {
+        key: "how_found",
+        label: "How did you find out about this opportunity?",
+        type: "multi_select",
+        required: true,
+        options: [
+            "Instagram",
+            "PMC Booth",
+            "LinkedIn",
+            "Word of Mouth",
+            "Previous PMC Events",
+            "PMC Newsletter",
+            "Other",
+        ],
+    },
+    {
+        key: "year",
+        label: "What year will you be going into in Fall 2026?",
+        type: "select",
+        required: true,
+        options: ["Year 1", "Year 2", "Year 3", "Year 4", "Year 5+"],
+    },
+    {
+        key: "faculty",
+        label: "Faculty",
+        type: "select",
+        required: true,
+        options: [
+            "Architecture",
+            "Arts",
+            "Applied Science",
+            "Sauder School of Business",
+            "Science",
+            "Land and Food Systems",
+            "Forestry",
+        ],
+    },
+    { key: "major", label: "Major", type: "short_text", required: true },
+    {
+        key: "why_exec",
+        label: "Why do you want to be an Exec at UBC PMC? What's in it for you?",
+        type: "long_text",
+        required: true,
+        maxWords: 150,
+    },
+    {
+        key: "why_pm",
+        label: "What makes you interested in Product Management, or the product space in general?",
+        type: "long_text",
+        required: true,
+        maxWords: 150,
+    },
+    {
+        key: "choice_rank",
+        label: "Is this your first-choice, second-choice, third+ choice, or the only position you're applying for?",
+        type: "select",
+        required: true,
+        options: [
+            "First Choice",
+            "Second Choice",
+            "Third+ Choice",
+            "Only Position I am Applying for",
+        ],
+    },
+    {
+        key: "commitments",
+        label: "Please elaborate on your commitments for Summer 2026, Fall 2026 and Winter 2026.",
+        type: "long_text",
+        required: true,
+    },
+    { key: "linkedin", label: "Share your LinkedIn with us, if you would like!", type: "short_text", required: false },
+    { key: "anything_else", label: "Is there anything you would like us to know?", type: "long_text", required: false },
+];
+
+// Role-specific questions layered on top of the base set. Only Developer is
+// filled in from the real form so far — the rest are placeholders to fill in
+// once the per-role questions are confirmed (prez meeting / #174).
+export const ROLE_QUESTIONS: Partial<Record<Position, Question[]>> = {
+    Developer: [
+        {
+            key: "technical_project",
+            label: "Tell us about a technical project where you chose a new technology — the goal, why that tech, and the biggest hurdles.",
+            type: "long_text",
+            required: true,
+            maxWords: 150,
+        },
+        {
+            key: "tech_to_learn",
+            label: "Is there a specific technology you're eager to learn more about? What excites you about it?",
+            type: "long_text",
+            required: true,
+            maxWords: 150,
+        },
+        { key: "cpsc_courses", label: "Share some of the CPSC courses (or equivalent) you've taken at UBC.", type: "short_text", required: false },
+        { key: "if_language", label: "If you could be a coding language, which one would it be and why?", type: "long_text", required: false },
+        { key: "portfolio_link", label: "Link to your work (Portfolio, Website, GitHub, etc.)", type: "short_text", required: true },
+    ],
+};
+
+// Returns the full question set for a position: base questions plus any
+// role-specific ones. Unknown positions just get the base set.
+export const getQuestionsForPosition = (position?: string): Question[] => {
+    const roleQuestions =
+        position && position in ROLE_QUESTIONS
+            ? ROLE_QUESTIONS[position as Position] ?? []
+            : [];
+    return [...BASE_QUESTIONS, ...roleQuestions];
+};

--- a/src/routes/v2/admin/application.ts
+++ b/src/routes/v2/admin/application.ts
@@ -1,0 +1,30 @@
+import { Request, Response, Router } from "express";
+import {
+    getApplication,
+    listApplications,
+} from "../../../services/Application/ApplicationService";
+
+export const applicationRouter = Router();
+
+applicationRouter.get("/", async (req: Request, res: Response) => {
+    try {
+        const applications = await listApplications();
+        return res.status(200).json(applications);
+    } catch (error: any) {
+        console.error(error);
+        return res.status(500).json({ error: error.message });
+    }
+});
+
+applicationRouter.get("/:id", async (req: Request, res: Response) => {
+    try {
+        const application = await getApplication(req.params.id);
+        if (!application) {
+            return res.status(404).json({ error: "Application not found" });
+        }
+        return res.status(200).json(application);
+    } catch (error: any) {
+        console.error(error);
+        return res.status(500).json({ error: error.message });
+    }
+});

--- a/src/routes/v2/admin/application.ts
+++ b/src/routes/v2/admin/application.ts
@@ -1,24 +1,72 @@
 import { Request, Response, Router } from "express";
+import { ApplicationStarSchema } from "../../../schema/v2/Application";
 import {
-    getApplication,
     listApplications,
+    setApplicationStar,
+    viewApplication,
 } from "../../../services/Application/ApplicationService";
 
 export const applicationRouter = Router();
 
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+// application_id is a uuid column — reject malformed ids up front so Postgres
+// doesn't turn them into "invalid input syntax" 500s.
+const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// List submitted applications, most recent first. Supports ?limit & ?offset;
+// returns { applications, total, limit, offset } so the dashboard can paginate.
 applicationRouter.get("/", async (req: Request, res: Response) => {
+    const parsedLimit = Number.parseInt(req.query.limit as string, 10);
+    const parsedOffset = Number.parseInt(req.query.offset as string, 10);
+    const limit = Number.isNaN(parsedLimit)
+        ? DEFAULT_LIMIT
+        : Math.min(Math.max(parsedLimit, 1), MAX_LIMIT);
+    const offset = Number.isNaN(parsedOffset) ? 0 : Math.max(parsedOffset, 0);
+
     try {
-        const applications = await listApplications();
-        return res.status(200).json(applications);
+        const { applications, total } = await listApplications(limit, offset);
+        return res.status(200).json({ applications, total, limit, offset });
     } catch (error: any) {
         console.error(error);
         return res.status(500).json({ error: error.message });
     }
 });
 
+// Viewing an application marks it UNDER_REVIEW the first time it is opened.
 applicationRouter.get("/:id", async (req: Request, res: Response) => {
+    if (!UUID_RE.test(req.params.id)) {
+        return res.status(404).json({ error: "Application not found" });
+    }
     try {
-        const application = await getApplication(req.params.id);
+        const application = await viewApplication(req.params.id);
+        if (!application) {
+            return res.status(404).json({ error: "Application not found" });
+        }
+        return res.status(200).json(application);
+    } catch (error: any) {
+        console.error(error);
+        return res.status(500).json({ error: error.message });
+    }
+});
+
+// Flag/unflag a standout applicant ("people we want").
+applicationRouter.patch("/:id/star", async (req: Request, res: Response) => {
+    if (!UUID_RE.test(req.params.id)) {
+        return res.status(404).json({ error: "Application not found" });
+    }
+    const result = ApplicationStarSchema.safeParse(req.body);
+    if (!result.success) {
+        return res.status(400).json({ error: result.error.message });
+    }
+
+    try {
+        const application = await setApplicationStar(
+            req.params.id,
+            result.data.is_starred
+        );
         if (!application) {
             return res.status(404).json({ error: "Application not found" });
         }

--- a/src/routes/v2/admin/index.ts
+++ b/src/routes/v2/admin/index.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { userRouter} from "./users";
 import { eventRouter } from "./event";
+import { applicationRouter } from "./application";
 
 export const adminRouter = Router();
 
 adminRouter.use("/users", userRouter)
 adminRouter.use("/events", eventRouter)
+adminRouter.use("/applications", applicationRouter)
 

--- a/src/routes/v2/application.ts
+++ b/src/routes/v2/application.ts
@@ -1,0 +1,51 @@
+import { Request, Response, Router } from "express";
+import { ApplicationSubmissionSchema } from "../../schema/v2/Application";
+import {
+    getApplicationByUser,
+    submitApplication,
+} from "../../services/Application/ApplicationService";
+
+export const applicationRouter = Router();
+
+// Submit an application for the authenticated applicant.
+applicationRouter.post("/", async (req: Request, res: Response) => {
+    const userId = req.user?.user_id;
+    if (!userId) {
+        return res.status(401).json({ error: "User not authenticated" });
+    }
+
+    const result = ApplicationSubmissionSchema.safeParse(req.body);
+    if (!result.success) {
+        return res.status(400).json({ error: result.error.message });
+    }
+
+    try {
+        const application = await submitApplication(
+            userId,
+            result.data.application_data
+        );
+        return res.status(201).json(application);
+    } catch (error: any) {
+        console.error(error);
+        return res.status(500).json({ error: error.message });
+    }
+});
+
+// Retrieve the authenticated applicant's own submission.
+applicationRouter.get("/me", async (req: Request, res: Response) => {
+    const userId = req.user?.user_id;
+    if (!userId) {
+        return res.status(401).json({ error: "User not authenticated" });
+    }
+
+    try {
+        const application = await getApplicationByUser(userId);
+        if (!application) {
+            return res.status(404).json({ error: "Application not found" });
+        }
+        return res.status(200).json(application);
+    } catch (error: any) {
+        console.error(error);
+        return res.status(500).json({ error: error.message });
+    }
+});

--- a/src/routes/v2/application.ts
+++ b/src/routes/v2/application.ts
@@ -1,17 +1,38 @@
 import { Request, Response, Router } from "express";
+import {
+    POSITIONS,
+    getQuestionsForPosition,
+} from "../../config/recruitingQuestions";
+import { authenticated } from "../../middleware/Session";
 import { ApplicationSubmissionSchema } from "../../schema/v2/Application";
 import {
-    getApplicationByUser,
+    getApplicationsByUser,
     submitApplication,
 } from "../../services/Application/ApplicationService";
 
 export const applicationRouter = Router();
 
-// Submit an application for the authenticated applicant.
-applicationRouter.post("/", async (req: Request, res: Response) => {
+// Public: the questions to render for an application form. Static config with
+// nothing sensitive, so applicants can see the form before logging in. Without
+// ?position returns the base questions; with one, base + that role's questions.
+applicationRouter.get("/questions", (req: Request, res: Response) => {
+    const position = req.query.position as string | undefined;
+    return res.status(200).json({
+        positions: POSITIONS,
+        position: position ?? null,
+        questions: getQuestionsForPosition(position),
+    });
+});
+
+// Submit an application for one position as the authenticated applicant.
+// Note the req.user guard is NOT redundant with `authenticated`: sessionFilter
+// verifies the token but still calls next() when no User row exists for it, so
+// req.user can be undefined here (e.g. a valid Auth0 account that never
+// completed onboarding).
+applicationRouter.post("/", ...authenticated, async (req: Request, res: Response) => {
     const userId = req.user?.user_id;
     if (!userId) {
-        return res.status(401).json({ error: "User not authenticated" });
+        return res.status(401).json({ error: "No user profile found for this account" });
     }
 
     const result = ApplicationSubmissionSchema.safeParse(req.body);
@@ -20,10 +41,7 @@ applicationRouter.post("/", async (req: Request, res: Response) => {
     }
 
     try {
-        const application = await submitApplication(
-            userId,
-            result.data.application_data
-        );
+        const application = await submitApplication(userId, result.data);
         return res.status(201).json(application);
     } catch (error: any) {
         console.error(error);
@@ -31,19 +49,16 @@ applicationRouter.post("/", async (req: Request, res: Response) => {
     }
 });
 
-// Retrieve the authenticated applicant's own submission.
-applicationRouter.get("/me", async (req: Request, res: Response) => {
+// Retrieve all of the authenticated applicant's submissions (one per position).
+applicationRouter.get("/me", ...authenticated, async (req: Request, res: Response) => {
     const userId = req.user?.user_id;
     if (!userId) {
-        return res.status(401).json({ error: "User not authenticated" });
+        return res.status(401).json({ error: "No user profile found for this account" });
     }
 
     try {
-        const application = await getApplicationByUser(userId);
-        if (!application) {
-            return res.status(404).json({ error: "Application not found" });
-        }
-        return res.status(200).json(application);
+        const applications = await getApplicationsByUser(userId);
+        return res.status(200).json(applications);
     } catch (error: any) {
         console.error(error);
         return res.status(500).json({ error: error.message });

--- a/src/routes/v2/index.ts
+++ b/src/routes/v2/index.ts
@@ -5,6 +5,7 @@ import { attendeeRouter } from "./attendee";
 import { profileRouter } from "./profile";
 import { paymentRouter } from "./payments";
 import { adminRouter } from "./admin";
+import { applicationRouter } from "./application";
 import { authenticated, supabaseJwtCheck } from "../../middleware/Session";
 
 export const v2ApiRouter = Router();
@@ -15,3 +16,4 @@ v2ApiRouter.use("/v2/events", eventRouter);
 v2ApiRouter.use("/v2/auth", authenticated, authRouter);
 v2ApiRouter.use("/v2/profile", authenticated, profileRouter);
 v2ApiRouter.use("/v2/attendee", authenticated, attendeeRouter);
+v2ApiRouter.use("/v2/application", authenticated, applicationRouter);

--- a/src/routes/v2/index.ts
+++ b/src/routes/v2/index.ts
@@ -16,4 +16,5 @@ v2ApiRouter.use("/v2/events", eventRouter);
 v2ApiRouter.use("/v2/auth", authenticated, authRouter);
 v2ApiRouter.use("/v2/profile", authenticated, profileRouter);
 v2ApiRouter.use("/v2/attendee", authenticated, attendeeRouter);
-v2ApiRouter.use("/v2/application", authenticated, applicationRouter);
+// Auth is applied per-route inside applicationRouter so GET /questions stays public.
+v2ApiRouter.use("/v2/application", applicationRouter);

--- a/src/schema/v2/Application.ts
+++ b/src/schema/v2/Application.ts
@@ -3,7 +3,10 @@ import { z } from "zod/v4";
 // Validates the public submission body. `user_id`, `status`, and
 // `submitted_at` are set by the server and must not be trusted from the client.
 export const ApplicationSubmissionSchema = z.object({
-    application_data: z.json(),
+    // jsonb NOT NULL in the DB — z.json() alone would accept `null`, so reject it here.
+    application_data: z.json().refine((value) => value !== null, {
+        message: "application_data is required",
+    }),
 });
 
 export type ApplicationSubmission = z.infer<typeof ApplicationSubmissionSchema>;

--- a/src/schema/v2/Application.ts
+++ b/src/schema/v2/Application.ts
@@ -1,0 +1,9 @@
+import { z } from "zod/v4";
+
+// Validates the public submission body. `user_id`, `status`, and
+// `submitted_at` are set by the server and must not be trusted from the client.
+export const ApplicationSubmissionSchema = z.object({
+    application_data: z.json(),
+});
+
+export type ApplicationSubmission = z.infer<typeof ApplicationSubmissionSchema>;

--- a/src/schema/v2/Application.ts
+++ b/src/schema/v2/Application.ts
@@ -1,12 +1,34 @@
 import { z } from "zod/v4";
 
-// Validates the public submission body. `user_id`, `status`, and
-// `submitted_at` are set by the server and must not be trusted from the client.
+// Validates an applicant submission for a single exec position. Applicants apply
+// once per position (see the unique(user_id, position) constraint). `user_id`,
+// `status`, and `submitted_at` are set by the server and not trusted from the client.
+//
+// Column-vs-jsonb split: fields the dashboard filters or sorts on (position,
+// choice_rank, resume_url) are dedicated columns; free-form question answers
+// live in application_data keyed by question key (see config/recruitingQuestions).
 export const ApplicationSubmissionSchema = z.object({
+    position: z.string().min(1, { message: "position is required" }),
     // jsonb NOT NULL in the DB — z.json() alone would accept `null`, so reject it here.
     application_data: z.json().refine((value) => value !== null, {
         message: "application_data is required",
     }),
+    // Where this position sits in the applicant's preferences ("First Choice", ...).
+    // Promoted out of application_data so reviewers can sort by it.
+    choice_rank: z.string().optional(),
+    // Resume handling (PR #183 review): for now this is a URL string — the
+    // frontend uploads the PDF to Supabase storage (see storage/Storage.ts
+    // uploadSupabaseFiles) and submits the resulting link. A dedicated
+    // multipart upload endpoint is a follow-up once the upload flow is decided.
+    resume_url: z.string().optional(),
 });
 
 export type ApplicationSubmission = z.infer<typeof ApplicationSubmissionSchema>;
+
+// Validates an admin/reviewer starring (or unstarring) an application to flag
+// standout applicants ("people we want").
+export const ApplicationStarSchema = z.object({
+    is_starred: z.boolean(),
+});
+
+export type ApplicationStar = z.infer<typeof ApplicationStarSchema>;

--- a/src/schema/v2/database.types.ts
+++ b/src/schema/v2/database.types.ts
@@ -72,6 +72,41 @@ export type Database = {
           },
         ]
       }
+      Application: {
+        Row: {
+          application_data: Json
+          application_id: string
+          form_id: string | null
+          status: Database["public"]["Enums"]["APPLICATION_STATUS"]
+          submitted_at: string
+          user_id: string
+        }
+        Insert: {
+          application_data: Json
+          application_id?: string
+          form_id?: string | null
+          status?: Database["public"]["Enums"]["APPLICATION_STATUS"]
+          submitted_at?: string
+          user_id: string
+        }
+        Update: {
+          application_data?: Json
+          application_id?: string
+          form_id?: string | null
+          status?: Database["public"]["Enums"]["APPLICATION_STATUS"]
+          submitted_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Application_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "User"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       birthdays: {
         Row: {
           birthday: string
@@ -526,6 +561,11 @@ export type Database = {
       }
     }
     Enums: {
+      APPLICATION_STATUS:
+        | "SUBMITTED"
+        | "UNDER_REVIEW"
+        | "ACCEPTED"
+        | "REJECTED"
       ATTENDEE_STATUS:
         | "FAILED"
         | "PROCESSING"
@@ -660,6 +700,12 @@ export type CompositeTypes<
 export const Constants = {
   public: {
     Enums: {
+      APPLICATION_STATUS: [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+      ],
       ATTENDEE_STATUS: [
         "FAILED",
         "PROCESSING",

--- a/src/schema/v2/database.types.ts
+++ b/src/schema/v2/database.types.ts
@@ -72,11 +72,14 @@ export type Database = {
           },
         ]
       }
-      Application: {
+      Exec_Application: {
         Row: {
           application_data: Json
           application_id: string
-          form_id: string | null
+          choice_rank: string | null
+          is_starred: boolean
+          position: string
+          resume_url: string | null
           status: Database["public"]["Enums"]["APPLICATION_STATUS"]
           submitted_at: string
           user_id: string
@@ -84,7 +87,10 @@ export type Database = {
         Insert: {
           application_data: Json
           application_id?: string
-          form_id?: string | null
+          choice_rank?: string | null
+          is_starred?: boolean
+          position: string
+          resume_url?: string | null
           status?: Database["public"]["Enums"]["APPLICATION_STATUS"]
           submitted_at?: string
           user_id: string
@@ -92,16 +98,19 @@ export type Database = {
         Update: {
           application_data?: Json
           application_id?: string
-          form_id?: string | null
+          choice_rank?: string | null
+          is_starred?: boolean
+          position?: string
+          resume_url?: string | null
           status?: Database["public"]["Enums"]["APPLICATION_STATUS"]
           submitted_at?: string
           user_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "Application_user_id_fkey"
+            foreignKeyName: "Exec_Application_user_id_fkey"
             columns: ["user_id"]
-            isOneToOne: true
+            isOneToOne: false
             referencedRelation: "User"
             referencedColumns: ["user_id"]
           },

--- a/src/services/Application/ApplicationService.ts
+++ b/src/services/Application/ApplicationService.ts
@@ -22,6 +22,13 @@ export const submitApplication = async (
         status: "SUBMITTED",
     });
     if (error) {
+        // Postgres unique_violation: the pre-check above raced with a concurrent
+        // submit. Map it back to the same friendly error rather than a raw 500.
+        if (error.code === "23505") {
+            throw new Error(
+                `User ${userId} has already submitted an application`
+            );
+        }
         throw new Error(`Failed to create application: ${error.message}`);
     }
     return data;

--- a/src/services/Application/ApplicationService.ts
+++ b/src/services/Application/ApplicationService.ts
@@ -1,0 +1,64 @@
+import { Json, Tables } from "../../schema/v2/database.types";
+import { ApplicationRepository } from "../../storage/ApplicationRepository";
+
+export const submitApplication = async (
+    userId: string,
+    applicationData: Json
+): Promise<Tables<"Application">> => {
+    const { data: existing, error: existingError } =
+        await ApplicationRepository.getApplicationByUser(userId);
+    if (existingError) {
+        throw new Error(
+            `Failed to check existing application for user ${userId}: ${existingError.message}`
+        );
+    }
+    if (existing) {
+        throw new Error(`User ${userId} has already submitted an application`);
+    }
+
+    const { data, error } = await ApplicationRepository.addApplication({
+        user_id: userId,
+        application_data: applicationData,
+        status: "SUBMITTED",
+    });
+    if (error) {
+        throw new Error(`Failed to create application: ${error.message}`);
+    }
+    return data;
+};
+
+export const getApplicationByUser = async (
+    userId: string
+): Promise<Tables<"Application"> | null> => {
+    const { data, error } = await ApplicationRepository.getApplicationByUser(
+        userId
+    );
+    if (error) {
+        throw new Error(
+            `Failed to get application for user ${userId}: ${error.message}`
+        );
+    }
+    return data;
+};
+
+export const listApplications = async (): Promise<Tables<"Application">[]> => {
+    const { data, error } = await ApplicationRepository.getApplications();
+    if (error) {
+        throw new Error(`Failed to list applications: ${error.message}`);
+    }
+    return data ?? [];
+};
+
+export const getApplication = async (
+    applicationId: string
+): Promise<Tables<"Application"> | null> => {
+    const { data, error } = await ApplicationRepository.getApplicationById(
+        applicationId
+    );
+    if (error) {
+        throw new Error(
+            `Failed to get application ${applicationId}: ${error.message}`
+        );
+    }
+    return data;
+};

--- a/src/services/Application/ApplicationService.ts
+++ b/src/services/Application/ApplicationService.ts
@@ -1,32 +1,38 @@
 import { Json, Tables } from "../../schema/v2/database.types";
 import { ApplicationRepository } from "../../storage/ApplicationRepository";
 
+type ExecApplication = Tables<"Exec_Application">;
+
+export interface NewApplication {
+    position: string;
+    application_data: Json;
+    choice_rank?: string;
+    resume_url?: string;
+}
+
+export interface PaginatedApplications {
+    applications: ExecApplication[];
+    total: number;
+}
+
 export const submitApplication = async (
     userId: string,
-    applicationData: Json
-): Promise<Tables<"Application">> => {
-    const { data: existing, error: existingError } =
-        await ApplicationRepository.getApplicationByUser(userId);
-    if (existingError) {
-        throw new Error(
-            `Failed to check existing application for user ${userId}: ${existingError.message}`
-        );
-    }
-    if (existing) {
-        throw new Error(`User ${userId} has already submitted an application`);
-    }
-
+    application: NewApplication
+): Promise<ExecApplication> => {
     const { data, error } = await ApplicationRepository.addApplication({
         user_id: userId,
-        application_data: applicationData,
+        position: application.position,
+        application_data: application.application_data,
+        choice_rank: application.choice_rank,
+        resume_url: application.resume_url,
         status: "SUBMITTED",
     });
     if (error) {
-        // Postgres unique_violation: the pre-check above raced with a concurrent
-        // submit. Map it back to the same friendly error rather than a raw 500.
+        // The unique(user_id, position) constraint is the single source of truth
+        // for duplicate submissions — map its violation to a friendly message.
         if (error.code === "23505") {
             throw new Error(
-                `User ${userId} has already submitted an application`
+                `User ${userId} has already applied for ${application.position}`
             );
         }
         throw new Error(`Failed to create application: ${error.message}`);
@@ -34,37 +40,84 @@ export const submitApplication = async (
     return data;
 };
 
-export const getApplicationByUser = async (
+export const getApplicationsByUser = async (
     userId: string
-): Promise<Tables<"Application"> | null> => {
-    const { data, error } = await ApplicationRepository.getApplicationByUser(
+): Promise<ExecApplication[]> => {
+    const { data, error } = await ApplicationRepository.getApplicationsByUser(
         userId
     );
     if (error) {
         throw new Error(
-            `Failed to get application for user ${userId}: ${error.message}`
+            `Failed to get applications for user ${userId}: ${error.message}`
         );
-    }
-    return data;
-};
-
-export const listApplications = async (): Promise<Tables<"Application">[]> => {
-    const { data, error } = await ApplicationRepository.getApplications();
-    if (error) {
-        throw new Error(`Failed to list applications: ${error.message}`);
     }
     return data ?? [];
 };
 
+export const listApplications = async (
+    limit: number,
+    offset: number
+): Promise<PaginatedApplications> => {
+    const { data, error, count } = await ApplicationRepository.getApplications(
+        limit,
+        offset
+    );
+    if (error) {
+        throw new Error(`Failed to list applications: ${error.message}`);
+    }
+    return { applications: data ?? [], total: count ?? 0 };
+};
+
 export const getApplication = async (
     applicationId: string
-): Promise<Tables<"Application"> | null> => {
+): Promise<ExecApplication | null> => {
     const { data, error } = await ApplicationRepository.getApplicationById(
         applicationId
     );
     if (error) {
         throw new Error(
             `Failed to get application ${applicationId}: ${error.message}`
+        );
+    }
+    return data;
+};
+
+// Fetch an application for reviewing, marking it UNDER_REVIEW the first time an
+// exec opens it (SUBMITTED -> UNDER_REVIEW; later statuses are never reverted).
+// Returns null when no application matches the id (caller should 404).
+export const viewApplication = async (
+    applicationId: string
+): Promise<ExecApplication | null> => {
+    const application = await getApplication(applicationId);
+    if (!application || application.status !== "SUBMITTED") {
+        return application;
+    }
+
+    const { error } = await ApplicationRepository.updateStatus(
+        applicationId,
+        "UNDER_REVIEW"
+    );
+    if (error) {
+        throw new Error(
+            `Failed to mark application ${applicationId} under review: ${error.message}`
+        );
+    }
+    return { ...application, status: "UNDER_REVIEW" };
+};
+
+// Star/unstar an application to flag standout applicants. Returns null when no
+// application matches the id (caller should 404).
+export const setApplicationStar = async (
+    applicationId: string,
+    isStarred: boolean
+): Promise<ExecApplication | null> => {
+    const { data, error } = await ApplicationRepository.setStarred(
+        applicationId,
+        isStarred
+    );
+    if (error) {
+        throw new Error(
+            `Failed to update star on application ${applicationId}: ${error.message}`
         );
     }
     return data;

--- a/src/storage/ApplicationRepository.ts
+++ b/src/storage/ApplicationRepository.ts
@@ -1,0 +1,11 @@
+import { supabase } from "../config/supabase";
+import { TablesInsert } from "../schema/v2/database.types";
+
+type Application = TablesInsert<"Application">;
+
+export const ApplicationRepository = {
+    addApplication: (application: Application) => supabase.from("Application").insert(application).select().single(),
+    getApplications: () => supabase.from("Application").select("*"),
+    getApplicationById: (applicationId: string) => supabase.from("Application").select("*").eq("application_id", applicationId).maybeSingle(),
+    getApplicationByUser: (userId: string) => supabase.from("Application").select("*").eq("user_id", userId).maybeSingle(),
+};

--- a/src/storage/ApplicationRepository.ts
+++ b/src/storage/ApplicationRepository.ts
@@ -1,11 +1,17 @@
 import { supabase } from "../config/supabase";
-import { TablesInsert } from "../schema/v2/database.types";
+import { Enums, TablesInsert } from "../schema/v2/database.types";
 
-type Application = TablesInsert<"Application">;
+type ExecApplication = TablesInsert<"Exec_Application">;
+
+// Applicant name is joined from User so the admin list/detail views can show it
+// without extra round-trips (see recruiting dashboard #35/#36).
+const WITH_APPLICANT = "*, User(first_name, last_name)";
 
 export const ApplicationRepository = {
-    addApplication: (application: Application) => supabase.from("Application").insert(application).select().single(),
-    getApplications: () => supabase.from("Application").select("*"),
-    getApplicationById: (applicationId: string) => supabase.from("Application").select("*").eq("application_id", applicationId).maybeSingle(),
-    getApplicationByUser: (userId: string) => supabase.from("Application").select("*").eq("user_id", userId).maybeSingle(),
+    addApplication: (application: ExecApplication) => supabase.from("Exec_Application").insert(application).select().single(),
+    getApplications: (limit: number, offset: number) => supabase.from("Exec_Application").select(WITH_APPLICANT, { count: "exact" }).order("submitted_at", { ascending: false }).range(offset, offset + limit - 1),
+    getApplicationById: (applicationId: string) => supabase.from("Exec_Application").select(WITH_APPLICANT).eq("application_id", applicationId).maybeSingle(),
+    getApplicationsByUser: (userId: string) => supabase.from("Exec_Application").select("*").eq("user_id", userId).order("submitted_at", { ascending: false }),
+    setStarred: (applicationId: string, isStarred: boolean) => supabase.from("Exec_Application").update({ is_starred: isStarred }).eq("application_id", applicationId).select().maybeSingle(),
+    updateStatus: (applicationId: string, status: Enums<"APPLICATION_STATUS">) => supabase.from("Exec_Application").update({ status }).eq("application_id", applicationId),
 };

--- a/tests/services/Application/ApplicationService.test.ts
+++ b/tests/services/Application/ApplicationService.test.ts
@@ -1,0 +1,151 @@
+import { Tables } from "../../../src/schema/v2/database.types";
+import {
+  submitApplication,
+  getApplicationByUser,
+  listApplications,
+  getApplication,
+} from "../../../src/services/Application/ApplicationService";
+import { ApplicationRepository } from "../../../src/storage/ApplicationRepository";
+
+type ApplicationRow = Tables<"Application">;
+
+const mockApplication: ApplicationRow = {
+  application_id: "app-123",
+  user_id: "user-123",
+  form_id: null,
+  application_data: { whyPm: "I love product" },
+  status: "SUBMITTED",
+  submitted_at: "2025-01-15T10:00:00.000Z",
+};
+
+describe("ApplicationService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("submitApplication", () => {
+    it("creates an application when the user has none", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+      (
+        ApplicationRepository.addApplication as jest.Mock
+      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+
+      const result = await submitApplication("user-123", {
+        whyPm: "I love product",
+      });
+
+      expect(result).toEqual(mockApplication);
+      expect(ApplicationRepository.addApplication).toHaveBeenCalledWith({
+        user_id: "user-123",
+        application_data: { whyPm: "I love product" },
+        status: "SUBMITTED",
+      });
+    });
+
+    it("rejects when the user already has an application", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+
+      await expect(
+        submitApplication("user-123", { whyPm: "again" })
+      ).rejects.toThrow("User user-123 has already submitted an application");
+      expect(ApplicationRepository.addApplication).not.toHaveBeenCalled();
+    });
+
+    it("throws when the duplicate check fails", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: { message: "lookup fail" } });
+
+      await expect(
+        submitApplication("user-123", {})
+      ).rejects.toThrow(
+        "Failed to check existing application for user user-123: lookup fail"
+      );
+    });
+
+    it("throws on insert error", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+      (
+        ApplicationRepository.addApplication as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: { message: "DB fail" } });
+
+      await expect(submitApplication("user-123", {})).rejects.toThrow(
+        "Failed to create application: DB fail"
+      );
+    });
+  });
+
+  describe("getApplicationByUser", () => {
+    it("returns the application", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+
+      expect(await getApplicationByUser("user-123")).toEqual(mockApplication);
+    });
+
+    it("throws on error", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: { message: "fail" } });
+
+      await expect(getApplicationByUser("user-123")).rejects.toThrow(
+        "Failed to get application for user user-123: fail"
+      );
+    });
+  });
+
+  describe("listApplications", () => {
+    it("returns all applications", async () => {
+      (
+        ApplicationRepository.getApplications as jest.Mock
+      ).mockResolvedValueOnce({ data: [mockApplication], error: null });
+
+      expect(await listApplications()).toEqual([mockApplication]);
+    });
+
+    it("returns an empty array when data is null", async () => {
+      (
+        ApplicationRepository.getApplications as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+
+      expect(await listApplications()).toEqual([]);
+    });
+
+    it("throws on error", async () => {
+      (
+        ApplicationRepository.getApplications as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: { message: "fail" } });
+
+      await expect(listApplications()).rejects.toThrow(
+        "Failed to list applications: fail"
+      );
+    });
+  });
+
+  describe("getApplication", () => {
+    it("returns the application by id", async () => {
+      (
+        ApplicationRepository.getApplicationById as jest.Mock
+      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+
+      expect(await getApplication("app-123")).toEqual(mockApplication);
+    });
+
+    it("throws on error", async () => {
+      (
+        ApplicationRepository.getApplicationById as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: { message: "fail" } });
+
+      await expect(getApplication("app-123")).rejects.toThrow(
+        "Failed to get application app-123: fail"
+      );
+    });
+  });
+});

--- a/tests/services/Application/ApplicationService.test.ts
+++ b/tests/services/Application/ApplicationService.test.ts
@@ -67,6 +67,22 @@ describe("ApplicationService", () => {
       );
     });
 
+    it("maps a unique-violation race to the 'already submitted' error", async () => {
+      (
+        ApplicationRepository.getApplicationByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+      (
+        ApplicationRepository.addApplication as jest.Mock
+      ).mockResolvedValueOnce({
+        data: null,
+        error: { code: "23505", message: "duplicate key value" },
+      });
+
+      await expect(submitApplication("user-123", {})).rejects.toThrow(
+        "User user-123 has already submitted an application"
+      );
+    });
+
     it("throws on insert error", async () => {
       (
         ApplicationRepository.getApplicationByUser as jest.Mock

--- a/tests/services/Application/ApplicationService.test.ts
+++ b/tests/services/Application/ApplicationService.test.ts
@@ -1,21 +1,33 @@
 import { Tables } from "../../../src/schema/v2/database.types";
 import {
   submitApplication,
-  getApplicationByUser,
+  getApplicationsByUser,
   listApplications,
   getApplication,
+  setApplicationStar,
+  viewApplication,
 } from "../../../src/services/Application/ApplicationService";
 import { ApplicationRepository } from "../../../src/storage/ApplicationRepository";
 
-type ApplicationRow = Tables<"Application">;
+type ExecApplicationRow = Tables<"Exec_Application">;
 
-const mockApplication: ApplicationRow = {
+const mockApplication: ExecApplicationRow = {
   application_id: "app-123",
   user_id: "user-123",
-  form_id: null,
+  position: "Developer",
+  choice_rank: "First Choice",
+  resume_url: "https://storage/resume.pdf",
   application_data: { whyPm: "I love product" },
+  is_starred: false,
   status: "SUBMITTED",
   submitted_at: "2025-01-15T10:00:00.000Z",
+};
+
+const newApplication = {
+  position: "Developer",
+  application_data: { whyPm: "I love product" },
+  choice_rank: "First Choice",
+  resume_url: "https://storage/resume.pdf",
 };
 
 describe("ApplicationService", () => {
@@ -24,53 +36,25 @@ describe("ApplicationService", () => {
   });
 
   describe("submitApplication", () => {
-    it("creates an application when the user has none", async () => {
-      (
-        ApplicationRepository.getApplicationByUser as jest.Mock
-      ).mockResolvedValueOnce({ data: null, error: null });
+    it("creates an application", async () => {
       (
         ApplicationRepository.addApplication as jest.Mock
       ).mockResolvedValueOnce({ data: mockApplication, error: null });
 
-      const result = await submitApplication("user-123", {
-        whyPm: "I love product",
-      });
+      const result = await submitApplication("user-123", newApplication);
 
       expect(result).toEqual(mockApplication);
       expect(ApplicationRepository.addApplication).toHaveBeenCalledWith({
         user_id: "user-123",
+        position: "Developer",
         application_data: { whyPm: "I love product" },
+        choice_rank: "First Choice",
+        resume_url: "https://storage/resume.pdf",
         status: "SUBMITTED",
       });
     });
 
-    it("rejects when the user already has an application", async () => {
-      (
-        ApplicationRepository.getApplicationByUser as jest.Mock
-      ).mockResolvedValueOnce({ data: mockApplication, error: null });
-
-      await expect(
-        submitApplication("user-123", { whyPm: "again" })
-      ).rejects.toThrow("User user-123 has already submitted an application");
-      expect(ApplicationRepository.addApplication).not.toHaveBeenCalled();
-    });
-
-    it("throws when the duplicate check fails", async () => {
-      (
-        ApplicationRepository.getApplicationByUser as jest.Mock
-      ).mockResolvedValueOnce({ data: null, error: { message: "lookup fail" } });
-
-      await expect(
-        submitApplication("user-123", {})
-      ).rejects.toThrow(
-        "Failed to check existing application for user user-123: lookup fail"
-      );
-    });
-
-    it("maps a unique-violation race to the 'already submitted' error", async () => {
-      (
-        ApplicationRepository.getApplicationByUser as jest.Mock
-      ).mockResolvedValueOnce({ data: null, error: null });
+    it("maps a unique-violation to an 'already applied for position' error", async () => {
       (
         ApplicationRepository.addApplication as jest.Mock
       ).mockResolvedValueOnce({
@@ -78,68 +62,80 @@ describe("ApplicationService", () => {
         error: { code: "23505", message: "duplicate key value" },
       });
 
-      await expect(submitApplication("user-123", {})).rejects.toThrow(
-        "User user-123 has already submitted an application"
-      );
+      await expect(
+        submitApplication("user-123", newApplication)
+      ).rejects.toThrow("User user-123 has already applied for Developer");
     });
 
-    it("throws on insert error", async () => {
-      (
-        ApplicationRepository.getApplicationByUser as jest.Mock
-      ).mockResolvedValueOnce({ data: null, error: null });
+    it("throws on a non-unique insert error", async () => {
       (
         ApplicationRepository.addApplication as jest.Mock
       ).mockResolvedValueOnce({ data: null, error: { message: "DB fail" } });
 
-      await expect(submitApplication("user-123", {})).rejects.toThrow(
-        "Failed to create application: DB fail"
-      );
+      await expect(
+        submitApplication("user-123", newApplication)
+      ).rejects.toThrow("Failed to create application: DB fail");
     });
   });
 
-  describe("getApplicationByUser", () => {
-    it("returns the application", async () => {
+  describe("getApplicationsByUser", () => {
+    it("returns the user's applications", async () => {
       (
-        ApplicationRepository.getApplicationByUser as jest.Mock
-      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+        ApplicationRepository.getApplicationsByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: [mockApplication], error: null });
 
-      expect(await getApplicationByUser("user-123")).toEqual(mockApplication);
+      expect(await getApplicationsByUser("user-123")).toEqual([mockApplication]);
+    });
+
+    it("returns an empty array when data is null", async () => {
+      (
+        ApplicationRepository.getApplicationsByUser as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+
+      expect(await getApplicationsByUser("user-123")).toEqual([]);
     });
 
     it("throws on error", async () => {
       (
-        ApplicationRepository.getApplicationByUser as jest.Mock
+        ApplicationRepository.getApplicationsByUser as jest.Mock
       ).mockResolvedValueOnce({ data: null, error: { message: "fail" } });
 
-      await expect(getApplicationByUser("user-123")).rejects.toThrow(
-        "Failed to get application for user user-123: fail"
+      await expect(getApplicationsByUser("user-123")).rejects.toThrow(
+        "Failed to get applications for user user-123: fail"
       );
     });
   });
 
   describe("listApplications", () => {
-    it("returns all applications", async () => {
+    it("returns paginated applications with a total count", async () => {
       (
         ApplicationRepository.getApplications as jest.Mock
-      ).mockResolvedValueOnce({ data: [mockApplication], error: null });
+      ).mockResolvedValueOnce({ data: [mockApplication], error: null, count: 1 });
 
-      expect(await listApplications()).toEqual([mockApplication]);
+      expect(await listApplications(20, 0)).toEqual({
+        applications: [mockApplication],
+        total: 1,
+      });
+      expect(ApplicationRepository.getApplications).toHaveBeenCalledWith(20, 0);
     });
 
-    it("returns an empty array when data is null", async () => {
+    it("defaults to empty list and zero total when data/count are null", async () => {
       (
         ApplicationRepository.getApplications as jest.Mock
-      ).mockResolvedValueOnce({ data: null, error: null });
+      ).mockResolvedValueOnce({ data: null, error: null, count: null });
 
-      expect(await listApplications()).toEqual([]);
+      expect(await listApplications(20, 0)).toEqual({
+        applications: [],
+        total: 0,
+      });
     });
 
     it("throws on error", async () => {
       (
         ApplicationRepository.getApplications as jest.Mock
-      ).mockResolvedValueOnce({ data: null, error: { message: "fail" } });
+      ).mockResolvedValueOnce({ data: null, error: { message: "fail" }, count: null });
 
-      await expect(listApplications()).rejects.toThrow(
+      await expect(listApplications(20, 0)).rejects.toThrow(
         "Failed to list applications: fail"
       );
     });
@@ -161,6 +157,94 @@ describe("ApplicationService", () => {
 
       await expect(getApplication("app-123")).rejects.toThrow(
         "Failed to get application app-123: fail"
+      );
+    });
+  });
+
+  describe("viewApplication", () => {
+    it("marks a SUBMITTED application UNDER_REVIEW on first view", async () => {
+      (
+        ApplicationRepository.getApplicationById as jest.Mock
+      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+      (
+        ApplicationRepository.updateStatus as jest.Mock
+      ).mockResolvedValueOnce({ error: null });
+
+      const result = await viewApplication("app-123");
+
+      expect(result?.status).toBe("UNDER_REVIEW");
+      expect(ApplicationRepository.updateStatus).toHaveBeenCalledWith(
+        "app-123",
+        "UNDER_REVIEW"
+      );
+    });
+
+    it("does not touch the status of an already-reviewed application", async () => {
+      const accepted = { ...mockApplication, status: "ACCEPTED" as const };
+      (
+        ApplicationRepository.getApplicationById as jest.Mock
+      ).mockResolvedValueOnce({ data: accepted, error: null });
+
+      const result = await viewApplication("app-123");
+
+      expect(result?.status).toBe("ACCEPTED");
+      expect(ApplicationRepository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the application does not exist", async () => {
+      (
+        ApplicationRepository.getApplicationById as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+
+      expect(await viewApplication("missing")).toBeNull();
+      expect(ApplicationRepository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it("throws when marking under review fails", async () => {
+      (
+        ApplicationRepository.getApplicationById as jest.Mock
+      ).mockResolvedValueOnce({ data: mockApplication, error: null });
+      (
+        ApplicationRepository.updateStatus as jest.Mock
+      ).mockResolvedValueOnce({ error: { message: "fail" } });
+
+      await expect(viewApplication("app-123")).rejects.toThrow(
+        "Failed to mark application app-123 under review: fail"
+      );
+    });
+  });
+
+  describe("setApplicationStar", () => {
+    it("returns the updated application", async () => {
+      const starred = { ...mockApplication, is_starred: true };
+      (
+        ApplicationRepository.setStarred as jest.Mock
+      ).mockResolvedValueOnce({ data: starred, error: null });
+
+      const result = await setApplicationStar("app-123", true);
+
+      expect(result).toEqual(starred);
+      expect(ApplicationRepository.setStarred).toHaveBeenCalledWith(
+        "app-123",
+        true
+      );
+    });
+
+    it("returns null when the application does not exist", async () => {
+      (
+        ApplicationRepository.setStarred as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: null });
+
+      expect(await setApplicationStar("missing", true)).toBeNull();
+    });
+
+    it("throws on error", async () => {
+      (
+        ApplicationRepository.setStarred as jest.Mock
+      ).mockResolvedValueOnce({ data: null, error: { message: "fail" } });
+
+      await expect(setApplicationStar("app-123", true)).rejects.toThrow(
+        "Failed to update star on application app-123: fail"
       );
     });
   });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -9,3 +9,4 @@ jest.mock('../src/storage/EventRepository');
 jest.mock('../src/storage/PaymentRepository');
 jest.mock('../src/storage/ProductRepository');
 jest.mock('../src/storage/CheckoutSessionRepository');
+jest.mock('../src/storage/ApplicationRepository');


### PR DESCRIPTION
## Description
Adds the backend for applicants to submit their applications and for admins to review them (part of the Recruiting Dashboard).


**What's included:**
- New `Application` table in Supabase to store submissions, with RLS enabled so it's only accessible through the backend. Includes a nullable `form_id` column, ready to link to the recruiting form (#174) once that table exists.


- **Applicant endpoints** (login required):
  - `POST /api/v2/application`  : submit an application
  - `GET /api/v2/application/me` : view your own submission
- **Admin endpoints:**
  - `GET /api/v2/admin/applications`  : list all submissions
  - `GET /api/v2/admin/applications/:id` : view one
  
  
- Added unit tests for the submission logic (including handling duplicate submissions).

**Note:**
- Admin endpoints currently let any logged-in user read submissions, reviewer-only access is deferred to tickets #178/#38.
- `form_id` isn't wired up yet; it needs the #174 form table before submissions can actually link to a form.